### PR TITLE
close #22 走行システムから競技開始合図を受け取る

### DIFF
--- a/camera_system/camera_system.py
+++ b/camera_system/camera_system.py
@@ -4,6 +4,8 @@
 @author: Takahiro55555 miyashita64
 """
 
+from client import Client
+
 
 class CameraSystem:
     """カメラシステムクラス."""
@@ -18,11 +20,12 @@ class CameraSystem:
 
     def start(self) -> None:
         """ゲーム攻略を計画する."""
-        # ToDo: 通信を確立する(通信).
-
         # ToDo: キャリブレーションする(ゲームエリア情報).
 
-        # ToDo: 開始合図を受け取るまで待機する(通信).
+        # 通信を開始する.
+        client = Client("127.0.0.1", 8080)
+        # 開始合図を受け取るまで待機する.
+        client.wait_for_start_signal()
 
         # ToDo: ゲームエリア情報を生成する(ゲームエリア情報).
 

--- a/camera_system/client.py
+++ b/camera_system/client.py
@@ -29,7 +29,7 @@ class Client:
             sock = socket.socket(socket.AF_INET)
 
             try:
-                # サーバーに接続する
+                # サーバに接続する
                 sock.connect((self.server_ip, self.server_port))
                 # レスポンスを受け取る
                 response = sock.recv(256).decode()
@@ -37,9 +37,9 @@ class Client:
                     print("Received '%s' Signal." % (response))
                 if response == "Start":
                     break
-            except ConnectionRefusedError:
+            except ConnectionRefusedError as e:
                 # 接続できなかった場合
-                print("Unconnected.")
+                print(e)
 
             # ソケットを削除する
             sock.close()

--- a/camera_system/client.py
+++ b/camera_system/client.py
@@ -1,0 +1,48 @@
+"""開始合図要求モジュール.
+
+走行システムに開始合図を要求する.
+@author miyashita64
+@note 参考 https://itsakura.com/python-socket
+"""
+
+import socket
+import time
+
+
+class Client:
+    """走行体から開始合図を受け取るまで要求を続けるクラス."""
+
+    def __init__(self, ip: str, port: int) -> None:
+        """Clientのコンストラクタ.
+
+        Args:
+            ip (string): サーバのIPアドレス
+            port (int): サーバのポート番号
+        """
+        self.server_ip = ip         # サーバのIPアドレス
+        self.server_port = port     # サーバのポート番号
+
+    def wait_for_start_signal(self) -> None:
+        """Start合図を受け取るまで要求を続ける."""
+        while True:
+            # ソケットを作成する
+            sock = socket.socket(socket.AF_INET)
+
+            try:
+                # サーバーに接続する
+                sock.connect((self.server_ip, self.server_port))
+                # レスポンスを受け取る
+                response = sock.recv(256).decode()
+                if response:
+                    print("Received '%s' Signal." % (response))
+                if response == "Start":
+                    break
+            except ConnectionRefusedError:
+                # 接続できなかった場合
+                print("Unconnected.")
+
+            # ソケットを削除する
+            sock.close()
+
+            # 1秒待機する
+            time.sleep(1)

--- a/tests/test_camera_system.py
+++ b/tests/test_camera_system.py
@@ -1,15 +1,20 @@
 """CameraSystemクラスのテストコードを記述するモジュール.
 
-@author: Takahiro55555
+@author: Takahiro55555 miyashita64
 """
 
 import unittest
-
-from camera_system.camera_system import CameraSystem
+from unittest import mock
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).parent.parent))
+sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
+from camera_system.camera_system import CameraSystem    # noqa
 
 
 class TestCameraSystem(unittest.TestCase):
-    def test_start(self):
+    @mock.patch('client.Client.wait_for_start_signal')
+    def test_start(self, client_func_mock):
         cs = CameraSystem()
         cs.start()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,22 @@
+"""Clientクラスのテストコードを記述するモジュール.
+@author: miyashita64
+"""
+
+import unittest
+from unittest import mock
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).parent.parent))
+sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
+from camera_system.client import Client   # noqa
+
+
+class TestClient(unittest.TestCase):
+    def test_constructor(self):
+        client = Client("127.0.0.1", 8080)
+
+    @mock.patch('socket.socket.connect', return_value=1)
+    @mock.patch('socket.socket.recv', return_value="Start".encode())
+    def test_wait_for_start_signal(self, connect_mock, recv_mock):
+        client = Client("127.0.0.1", 8080)
+        client.wait_for_start_signal()


### PR DESCRIPTION
## チェックリスト

- [x] format(autopep8) している
- [x] コーディング規約(pep8)に準じている
- [x] チケットの完了条件を満たしている

## 変更点
- 走行システムから競技開始合図を受け取るまで待機する処理を追加

### 通信手順
1. 走行システムのサーバに接続する
1. 開始合図('Start')を受け取るまで、要求を続ける
1. 開始合図を受け取ると次の処理に移る

[走行システムの変更](https://github.com/KatLab-MiyazakiUniv/etrobocon2022/pull/108)

## 動作テスト
### 実験方法
カメラシステムへ競技開始合図を送り、カメラシステムがそれを受信していることを確認する。

### 実験データ
https://user-images.githubusercontent.com/83441177/187383522-575b8f44-83ed-431d-8583-cc70637f384e.MOV

### 実験結果
走行システムからの競技開始合図を受信できた。

### 参考資料
[Python ソケット通信のサンプル](https://itsakura.com/python-socket)
[Pythonでunittestを行うとき、参照パスがずれる問題](https://qiita.com/TakamiChie/items/9d576b6718e866ef21ab)