### PR TITLE
close #30 CIが失敗した際にSlackへ通知する

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -53,6 +53,7 @@ jobs:
         run: |
           poetry run python -m pycodestyle camera_system/ tests/
           poetry run python -m pydocstyle camera_system/ tests/
+          exit 1  # わざと失敗する
 
       # 参考資料
       # - Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -53,7 +53,6 @@ jobs:
         run: |
           poetry run python -m pycodestyle camera_system/ tests/
           poetry run python -m pydocstyle camera_system/ tests/
-          exit 1  # わざと失敗する
 
       # 参考資料
       # - Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -53,3 +53,39 @@ jobs:
         run: |
           poetry run python -m pycodestyle camera_system/ tests/
           poetry run python -m pydocstyle camera_system/ tests/
+
+      # 参考資料
+      # - Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita
+      #     https://qiita.com/seratch/items/28d09eacada09134c96c
+      # - GitHub Actionsで1つ以上のジョブが失敗した場合にSlackに通知する
+      #     https://zenn.dev/ntoy/articles/3e7521cd39a75b
+      # NOTE:
+      #   "Repository: <${{ [以下略]"の部分は、良い感じに改行する方法を見つけられなかった...
+      - name: Failure Notification
+        if: failure()
+        uses: slackapi/slack-github-action@v1.21.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: CI結果: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ job.status }}>"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -80,7 +80,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: `${{ github.ref_name }}`\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
                     }
                   ]
                 }

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -80,7 +80,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
+                      "text": "Repository: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>\nBranch: ${{ github.ref_name }}\nWorkflow: `${{ github.workflow }}`\nAuthor: <https://github.com/${{ github.event.sender.login }}|@${{ github.event.sender.login }}>"
                     }
                   ]
                 }


### PR DESCRIPTION
# チェックリスト

- [ ] ~~clang-format している~~
- [ ] ~~コーディング規約に準じている~~
- [X] チケットの完了条件を満たしている

# 変更点
- CI失敗時にSlackへ通知するように変更

# 動作テスト

## 実験方法
わざと失敗するCIファイルをPushし、Slackへ通知が飛ぶことを確認した。

## 実験結果
以下、通知実験。
![image (5)](https://user-images.githubusercontent.com/31930148/188319817-7f193d0a-4513-4255-bd10-1fdf73f508e6.jpg)

## 添付資料
- [GitHub Actionsで1つ以上のジョブが失敗した場合にSlackに通知する]()
- [Slack が提供する GitHub Action "slack-send" を使って GitHub から Slack に通知する - Qiita](https://qiita.com/seratch/items/28d09eacada09134c96c)
