### PR TITLE
close #39 unittestの冗長な記述を削除する

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Generage coverage report
         id: generate_coverage_report
         run: |
-          poetry run python -m coverage run --source=camera_system/ -m unittest discover -s tests/
+          poetry run python -m coverage run --source=camera_system/ -m unittest discover
           
           # Job Summaries にカバレッジの概要を設定する
           echo '## Coverage'                   >> ${GITHUB_STEP_SUMMARY}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test:
 	poetry run python -m unittest
 
 coverage:
-	poetry run python -m coverage run --source=camera_system/ -m unittest discover -s tests/
+	poetry run python -m coverage run --source=camera_system/ -m unittest discover
 	poetry run python -m coverage report
 
 # NOTE: htmlcovディレクトリが生成され、index.htmlをブラウザで開くことでカバレッジを視覚的に確認できる

--- a/camera_system/game_area_info.py
+++ b/camera_system/game_area_info.py
@@ -4,7 +4,7 @@
 @author: kodama0720
 """
 
-from typing import List, Tuple, Dict
+from typing import List
 from robot import Robot, Direction
 from color_changer import Color
 from node import Node, NodeType

--- a/camera_system/game_area_info.py
+++ b/camera_system/game_area_info.py
@@ -8,7 +8,7 @@ from typing import List, Tuple, Dict
 from robot import Robot, Direction
 from color_changer import Color
 from node import Node, NodeType
-from coordinate import Coordinate
+from camera_system.coordinate import Coordinate
 
 
 class GameAreaInfo:

--- a/camera_system/game_area_info.py
+++ b/camera_system/game_area_info.py
@@ -8,7 +8,7 @@ from typing import List
 from robot import Robot, Direction
 from color_changer import Color
 from node import Node, NodeType
-from camera_system.coordinate import Coordinate
+from coordinate import Coordinate
 
 
 class GameAreaInfo:

--- a/camera_system/middle_to_block.py
+++ b/camera_system/middle_to_block.py
@@ -5,7 +5,7 @@
 @author mutotaka0426
 """
 
-from game_motion import Edge, GameMotion
+from game_motion import GameMotion
 
 
 class MiddleToBlock(GameMotion):

--- a/camera_system/middle_to_intersection.py
+++ b/camera_system/middle_to_intersection.py
@@ -5,7 +5,7 @@
 @author mutotaka0426
 """
 
-from game_motion import Edge, GameMotion
+from game_motion import GameMotion
 
 
 class MiddleToIntersection(GameMotion):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,3 +3,8 @@
 NOTE: このファイルが無いと、'python -m unittest'コマンドで'tests'ディレクトリ配下のテストコードを実行できない
 @author: Takahiro55555
 """
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).parent.parent))
+sys.path.append(str(Path(__file__).parent.parent / "camera_system"))

--- a/tests/test_block_to_intersection.py
+++ b/tests/test_block_to_intersection.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.block_to_intersection import BlockToIntersection  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.block_to_intersection import BlockToIntersection
 
 
 class TestBlockToIntersection(unittest.TestCase):

--- a/tests/test_block_to_middle.py
+++ b/tests/test_block_to_middle.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.block_to_middle import BlockToMiddle  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.block_to_middle import BlockToMiddle
 
 
 class TestBlockToMiddle(unittest.TestCase):

--- a/tests/test_camera_calibrator.py
+++ b/tests/test_camera_calibrator.py
@@ -5,13 +5,8 @@
 
 import unittest
 from unittest import mock
-import os
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
 
-from camera_system.camera_calibrator import CameraCalibrator  # noqa
+from camera_system.camera_calibrator import CameraCalibrator
 
 
 class TestCameraCalibrator(unittest.TestCase):

--- a/tests/test_camera_system.py
+++ b/tests/test_camera_system.py
@@ -5,11 +5,7 @@
 import unittest
 from unittest import mock
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.camera_system import CameraSystem  # noqa
+from camera_system.camera_system import CameraSystem
 
 
 class TestCameraSystem(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,11 +4,7 @@
 
 import unittest
 from unittest import mock
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.client import Client   # noqa
+from camera_system.client import Client
 
 
 class TestClient(unittest.TestCase):

--- a/tests/test_color_changer.py
+++ b/tests/test_color_changer.py
@@ -6,11 +6,7 @@
 import unittest
 import cv2
 import os
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.color_changer import ColorChanger  # noqa
+from camera_system.color_changer import ColorChanger
 
 
 class TestColorChanger(unittest.TestCase):

--- a/tests/test_composite_game_motion.py
+++ b/tests/test_composite_game_motion.py
@@ -6,16 +6,16 @@
 import unittest
 
 from camera_system.composite_game_motion import CompositeGameMotion
-from block_to_intersection import BlockToIntersection
-from block_to_middle import BlockToMiddle
-from intersection_to_block import IntersectionToBlock
-from intersection_to_middle import IntersectionToMiddle
-from middle_to_block import MiddleToBlock
-from middle_to_intersection import MiddleToIntersection
-from middle_to_middle import MiddleToMiddle
-from return_to_intersection import ReturnToIntersection
-from return_to_middle import ReturnToMiddle
-from return_to_block import ReturnToBlock
+from camera_system.block_to_intersection import BlockToIntersection
+from camera_system.block_to_middle import BlockToMiddle
+from camera_system.intersection_to_block import IntersectionToBlock
+from camera_system.intersection_to_middle import IntersectionToMiddle
+from camera_system.middle_to_block import MiddleToBlock
+from camera_system.middle_to_intersection import MiddleToIntersection
+from camera_system.middle_to_middle import MiddleToMiddle
+from camera_system.return_to_intersection import ReturnToIntersection
+from camera_system.return_to_middle import ReturnToMiddle
+from camera_system.return_to_block import ReturnToBlock
 
 
 class TestCompositeGameMotion(unittest.TestCase):

--- a/tests/test_composite_game_motion.py
+++ b/tests/test_composite_game_motion.py
@@ -5,21 +5,17 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.composite_game_motion import CompositeGameMotion  # noqa
-from block_to_intersection import BlockToIntersection  # noqa
-from block_to_middle import BlockToMiddle  # noqa
-from intersection_to_block import IntersectionToBlock  # noqa
-from intersection_to_middle import IntersectionToMiddle  # noqa
-from middle_to_block import MiddleToBlock  # noqa
-from middle_to_intersection import MiddleToIntersection  # noqa
-from middle_to_middle import MiddleToMiddle  # noqa
-from return_to_intersection import ReturnToIntersection  # noqa
-from return_to_middle import ReturnToMiddle  # noqa
-from return_to_block import ReturnToBlock  # noqa
+from camera_system.composite_game_motion import CompositeGameMotion
+from block_to_intersection import BlockToIntersection
+from block_to_middle import BlockToMiddle
+from intersection_to_block import IntersectionToBlock
+from intersection_to_middle import IntersectionToMiddle
+from middle_to_block import MiddleToBlock
+from middle_to_intersection import MiddleToIntersection
+from middle_to_middle import MiddleToMiddle
+from return_to_intersection import ReturnToIntersection
+from return_to_middle import ReturnToMiddle
+from return_to_block import ReturnToBlock
 
 
 class TestCompositeGameMotion(unittest.TestCase):

--- a/tests/test_game_area_info.py
+++ b/tests/test_game_area_info.py
@@ -20,7 +20,7 @@ class TestGameAreaInfo(unittest.TestCase):
         expected = [Coordinate(2, 0), Coordinate(3, 0), Coordinate(4, 0)]
         actual = GameAreaInfo.get_candidate_node(color)
 
-        self.assertEqual(expected, actual)
+        self.assertEqual(str(expected), str(actual))
 
     # 未運搬のブロック置き場があるブロック置き場を取得するテスト
     def test_get_no_transported_block(self):
@@ -33,7 +33,7 @@ class TestGameAreaInfo(unittest.TestCase):
         actual = GameAreaInfo.get_no_transported_block()
         for i in range(len(actual)):
             self.assertEqual(expected[i].block_id, actual[i].block_id)
-            self.assertEqual(expected[i].coord, actual[i].coord)
+            self.assertEqual(str(expected[i].coord), str(actual[i].coord))
             self.assertEqual(expected[i].node_type, actual[i].node_type)
 
     # 走行禁止座標を取得するテスト
@@ -45,7 +45,7 @@ class TestGameAreaInfo(unittest.TestCase):
         ]
         actual = GameAreaInfo.get_no_entry_coordinate(robo)
 
-        self.assertEqual(expected, actual)
+        self.assertEqual(str(expected), str(actual))
 
     # 回頭禁止方向を取得するテスト
     def test_get_no_rotate_direction(self):
@@ -53,4 +53,4 @@ class TestGameAreaInfo(unittest.TestCase):
         expected = [0, 4, 5, 6, 7]
         actual = GameAreaInfo.get_no_rotate_direction(robo)
 
-        self.assertEqual(expected, actual)
+        self.assertEqual(str(expected), str(actual))

--- a/tests/test_game_area_info.py
+++ b/tests/test_game_area_info.py
@@ -10,7 +10,7 @@ from camera_system.game_area_info import GameAreaInfo
 from camera_system.color_changer import Color
 from camera_system.robot import Direction, Robot
 from camera_system.node import NodeType, Node
-from coordinate import Coordinate
+from camera_system.coordinate import Coordinate
 
 
 class TestGameAreaInfo(unittest.TestCase):

--- a/tests/test_game_area_info.py
+++ b/tests/test_game_area_info.py
@@ -6,15 +6,11 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_area_info import GameAreaInfo  # noqa
-from camera_system.color_changer import Color  # noqa
-from camera_system.robot import Direction, Robot  # noqa
-from camera_system.node import NodeType, Node  # noqa
-from coordinate import Coordinate  # noqa
+from camera_system.game_area_info import GameAreaInfo
+from camera_system.color_changer import Color
+from camera_system.robot import Direction, Robot
+from camera_system.node import NodeType, Node
+from coordinate import Coordinate
 
 
 class TestGameAreaInfo(unittest.TestCase):

--- a/tests/test_game_area_info.py
+++ b/tests/test_game_area_info.py
@@ -23,12 +23,7 @@ class TestGameAreaInfo(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     # 未運搬のブロック置き場があるブロック置き場を取得するテスト
-
     def test_get_no_transported_block(self):
-        color = Color.BLUE.value
-        cross = NodeType.CROSS.value
-        middle = NodeType.MIDDLE.value
-        block_storage = NodeType.BLOCK.value
         expected = [
             Node(0, Coordinate(1, 1)), Node(1, Coordinate(3, 1)),
             Node(2, Coordinate(5, 1)), Node(3, Coordinate(1, 3)),

--- a/tests/test_intersection_to_block.py
+++ b/tests/test_intersection_to_block.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.intersection_to_block import IntersectionToBlock  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.intersection_to_block import IntersectionToBlock
 
 
 class TestIntersectionToBlock(unittest.TestCase):

--- a/tests/test_intersection_to_middle.py
+++ b/tests/test_intersection_to_middle.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.intersection_to_middle import IntersectionToMiddle  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.intersection_to_middle import IntersectionToMiddle
 
 
 class TestIntersectionToMiddle(unittest.TestCase):

--- a/tests/test_middle_to_block.py
+++ b/tests/test_middle_to_block.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from camera_system.game_motion import Edge, GameMotion
+from camera_system.game_motion import GameMotion
 from camera_system.middle_to_block import MiddleToBlock
 
 

--- a/tests/test_middle_to_block.py
+++ b/tests/test_middle_to_block.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import Edge, GameMotion  # noqa
-from camera_system.middle_to_block import MiddleToBlock  # noqa
+from camera_system.game_motion import Edge, GameMotion
+from camera_system.middle_to_block import MiddleToBlock
 
 
 class TestMiddleToBlock(unittest.TestCase):

--- a/tests/test_middle_to_intersection.py
+++ b/tests/test_middle_to_intersection.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from camera_system.game_motion import Edge, GameMotion
+from camera_system.game_motion import GameMotion
 from camera_system.middle_to_intersection import MiddleToIntersection
 
 

--- a/tests/test_middle_to_intersection.py
+++ b/tests/test_middle_to_intersection.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import Edge, GameMotion  # noqa
-from camera_system.middle_to_intersection import MiddleToIntersection  # noqa
+from camera_system.game_motion import Edge, GameMotion
+from camera_system.middle_to_intersection import MiddleToIntersection
 
 
 class TestMiddleToIntersection(unittest.TestCase):

--- a/tests/test_middle_to_middle.py
+++ b/tests/test_middle_to_middle.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.middle_to_middle import MiddleToMiddle  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.middle_to_middle import MiddleToMiddle
 
 
 class TestMiddleToMiddle(unittest.TestCase):

--- a/tests/test_return_to_block.py
+++ b/tests/test_return_to_block.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.return_to_block import ReturnToBlock  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.return_to_block import ReturnToBlock
 
 
 class TestReturnToBlock(unittest.TestCase):

--- a/tests/test_return_to_intersection.py
+++ b/tests/test_return_to_intersection.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.return_to_intersection import ReturnToIntersection  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.return_to_intersection import ReturnToIntersection
 
 
 class TestReturnToIntersection(unittest.TestCase):

--- a/tests/test_return_to_middle.py
+++ b/tests/test_return_to_middle.py
@@ -5,12 +5,8 @@
 
 import unittest
 
-from pathlib import Path
-import sys
-sys.path.append(str(Path(__file__).parent.parent))
-sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
-from camera_system.game_motion import GameMotion  # noqa
-from camera_system.return_to_middle import ReturnToMiddle  # noqa
+from camera_system.game_motion import GameMotion
+from camera_system.return_to_middle import ReturnToMiddle
 
 
 class TestReturnToMiddle(unittest.TestCase):


### PR DESCRIPTION
## チェックリスト

- [X] format(autopep8) している
- [X] コーディング規約(pep8)に準じている
- [X] チケットの完了条件を満たしている

## 変更点
- 不要な`import`文の削除
- 未使用変数の削除
- 各テストファイルに記述されていた以下の記述を、`tests/__init__.py`に移した
```
from pathlib import Path
import sys
sys.path.append(str(Path(__file__).parent.parent))
sys.path.append(str(Path(__file__).parent.parent / "camera_system"))
```

## 動作テスト
ローカル環境(WSL・Windows)とCI環境で正常にテスト及びカバレッジを出力できることを確認した。

### 実験結果
以下に、ローカル環境で実行した際のスクリーンショットを添付する。
![キャプチャ](https://user-images.githubusercontent.com/31930148/189073291-82f22bad-6a0f-40fe-968d-74898ff3d3d3.PNG)