### PR TITLE
close #70 ゲームエリア動作のコスト算出

### DIFF
--- a/camera_system/block_to_intersection.py
+++ b/camera_system/block_to_intersection.py
@@ -35,8 +35,8 @@ class BlockToIntersection(GameMotion):
             self.__rotation_time = GameMotion.ROTATION_NO_BLOCK_TABLE[abs(angle)]["time"]
         self.__direct_rotation = "clockwise" if angle > 0 else "anticlockwise"
         self.__target_color = target_color
-        self.__motion_time = 1.0700
-        self.__success_rate = 1.0
+        self.__motion_time = 1.086
+        self.__success_rate = 0.78
 
     def generate_command(self) -> str:
         """ブロック置き場→交点のゲーム動作に必要なコマンドを生成するメソッド.

--- a/camera_system/block_to_middle.py
+++ b/camera_system/block_to_middle.py
@@ -28,8 +28,8 @@ class BlockToMiddle(GameMotion):
             self.__rotation_pwm = GameMotion.ROTATION_NO_BLOCK_PWM
             self.__rotation_time = GameMotion.ROTATION_NO_BLOCK_TABLE[abs(angle)]["time"]
         self.__direct_rotation = "clockwise" if angle > 0 else "anticlockwise"
-        self.__motion_time = 0.8094
-        self.__success_rate = 0.9
+        self.__motion_time = 0.8285
+        self.__success_rate = 0.62
 
     def generate_command(self) -> str:
         """ブロック置き場→中点のゲーム動作に必要なコマンドを生成するメソッド.

--- a/camera_system/intersection_to_block.py
+++ b/camera_system/intersection_to_block.py
@@ -53,8 +53,8 @@ class IntersectionToBlock(GameMotion):
         self.__direct_rotation = "clockwise" if angle > 0 else "anticlockwise"
         self.__vertical_flag = vertical_flag
         self.__diagonal_flag = diagonal_flag
-        self.__motion_time = 0.7840
-        self.__success_rate = 1.0
+        self.__motion_time = 0.8615
+        self.__success_rate = 0.9
 
     def generate_command(self) -> str:
         """交点→ブロック置き場のゲーム動作に必要なコマンドを生成するメソッド.

--- a/camera_system/intersection_to_middle.py
+++ b/camera_system/intersection_to_middle.py
@@ -32,8 +32,8 @@ class IntersectionToMiddle(GameMotion):
             self.__rotation_time = GameMotion.ROTATION_NO_BLOCK_TABLE[abs(angle)]["time"]
         self.__direct_rotation = "clockwise" if angle > 0 else "anticlockwise"
         self.__need_adjustment = need_adjustment
-        self.__motion_time = 0.5480
-        self.__success_rate = 0.8
+        self.__motion_time = 0.553
+        self.__success_rate = 0.94
 
     def generate_command(self) -> str:
         """交点→中点のゲーム動作に必要なコマンドを生成するメソッド.

--- a/camera_system/middle_to_block.py
+++ b/camera_system/middle_to_block.py
@@ -31,8 +31,8 @@ class MiddleToBlock(GameMotion):
             self.__rotation_time = GameMotion.ROTATION_NO_BLOCK_TABLE[abs(angle)]["time"]
         self.__direct_rotation = "clockwise" if angle > 0 else "anticlockwise"
         self.__need_adjustment = need_adjustment
-        self.__motion_time = 0.6970
-        self.__success_rate = 1.0
+        self.__motion_time = 0.697
+        self.__success_rate = 0.78
 
     def generate_command(self) -> str:
         """中点→ブロック置き場のゲーム動作に必要なコマンドを生成するメソッド.

--- a/camera_system/middle_to_intersection.py
+++ b/camera_system/middle_to_intersection.py
@@ -38,8 +38,8 @@ class MiddleToIntersection(GameMotion):
             self.__rotation_time = GameMotion.ROTATION_NO_BLOCK_TABLE[abs(angle)]["time"]
         self.__direct_rotation = "clockwise" if angle > 0 else "anticlockwise"
         self.__target_color = target_color
-        self.__motion_time = 0.5560
-        self.__success_rate = 0.8
+        self.__motion_time = 0.645
+        self.__success_rate = 0.96
 
     def generate_command(self) -> str:
         """中点→交点のゲーム動作に必要なコマンドを生成するメソッド.

--- a/camera_system/middle_to_middle.py
+++ b/camera_system/middle_to_middle.py
@@ -32,8 +32,8 @@ class MiddleToMiddle(GameMotion):
             self.__rotation_time = GameMotion.ROTATION_NO_BLOCK_TABLE[abs(angle)]["time"]
         self.__direct_rotation = "clockwise" if angle > 0 else "anticlockwise"
         self.__need_adjustment = need_adjustment
-        self.__motion_time = 1.1490
-        self.__success_rate = 0.5
+        self.__motion_time = 1.3415
+        self.__success_rate = 0.6
 
     def generate_command(self) -> str:
         """中点→中点のゲーム動作に必要なコマンドを生成するメソッド.

--- a/tests/test_block_to_intersection.py
+++ b/tests/test_block_to_intersection.py
@@ -21,9 +21,9 @@ class TestBlockToIntersection(unittest.TestCase):
         b2i.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 1.0700 + \
+        motion_time = 1.086 + \
             GameMotion.ROTATION_BLOCK_TABLE[180]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 1.0
+        success_rate = 0.78
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = b2i.get_cost()  # 実際のコスト
@@ -55,9 +55,9 @@ class TestBlockToIntersection(unittest.TestCase):
         b2i.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 1.0700 + \
+        motion_time = 1.086 + \
             GameMotion.ROTATION_BLOCK_TABLE[225]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 1.0
+        success_rate = 0.78
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = b2i.get_cost()  # 実際のコスト
@@ -89,9 +89,9 @@ class TestBlockToIntersection(unittest.TestCase):
         b2i.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 1.0700 + \
+        motion_time = 1.086 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[270]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 1.0
+        success_rate = 0.78
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = b2i.get_cost()  # 実際のコスト
@@ -123,9 +123,9 @@ class TestBlockToIntersection(unittest.TestCase):
         b2i.current_edge = "none"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 1.0700 + \
+        motion_time = 1.086 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[315]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 1.0
+        success_rate = 0.78
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = b2i.get_cost()  # 実際のコスト

--- a/tests/test_block_to_middle.py
+++ b/tests/test_block_to_middle.py
@@ -19,9 +19,9 @@ class TestBlockToMiddle(unittest.TestCase):
         b2m.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.8094 + \
+        motion_time = 0.8285 + \
             GameMotion.ROTATION_BLOCK_TABLE[45]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.9
+        success_rate = 0.62
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = b2m.get_cost()  # 実際のコスト

--- a/tests/test_intersection_to_block.py
+++ b/tests/test_intersection_to_block.py
@@ -24,12 +24,12 @@ class TestIntersectionToBlock(unittest.TestCase):
         i2b.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.7840
+        motion_time = 0.8615
         # 2回分の回頭のスリープ時間を足す
         motion_time += GameMotion.ROTATION_BLOCK_TABLE[45]["time"] + GameMotion.SLEEP_TIME * 2
         motion_time += GameMotion.ROTATION_BLOCK_TABLE[45]["time"] + GameMotion.SLEEP_TIME * 2
         motion_time += GameMotion.VERTICAL_TIME
-        success_rate = 1.0
+        success_rate = 0.9
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2b.get_cost()  # 実際のコスト
@@ -69,10 +69,10 @@ class TestIntersectionToBlock(unittest.TestCase):
         i2b.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.7840
+        motion_time = 0.8615
         motion_time += GameMotion.ROTATION_BLOCK_TABLE[45]["time"] + GameMotion.SLEEP_TIME * 2
         motion_time += GameMotion.DIAGONAL_TIME
-        success_rate = 1.0
+        success_rate = 0.9
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2b.get_cost()  # 実際のコスト
@@ -108,10 +108,10 @@ class TestIntersectionToBlock(unittest.TestCase):
         i2b.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.7840
+        motion_time = 0.8615
         motion_time += GameMotion.ROTATION_NO_BLOCK_TABLE[180]["time"] + GameMotion.SLEEP_TIME * 2
         motion_time += GameMotion.ROTATION_NO_BLOCK_TABLE[45]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 1.0
+        success_rate = 0.9
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2b.get_cost()  # 実際のコスト
@@ -159,8 +159,8 @@ class TestIntersectionToBlock(unittest.TestCase):
         i2b.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.7840 + GameMotion.DIAGONAL_TIME
-        success_rate = 1.0
+        motion_time = 0.8615 + GameMotion.DIAGONAL_TIME
+        success_rate = 0.9
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2b.get_cost()  # 実際のコスト

--- a/tests/test_intersection_to_middle.py
+++ b/tests/test_intersection_to_middle.py
@@ -21,10 +21,10 @@ class TestIntersectionToMiddle(unittest.TestCase):
         i2m.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5480 + \
+        motion_time = 0.553 + \
             GameMotion.ROTATION_BLOCK_TABLE[270]["time"] + \
             GameMotion.VERTICAL_TIME + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.94
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2m.get_cost()  # 実際のコスト
@@ -53,9 +53,9 @@ class TestIntersectionToMiddle(unittest.TestCase):
         i2m.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5480 + \
+        motion_time = 0.553 + \
             GameMotion.ROTATION_BLOCK_TABLE[315]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.94
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2m.get_cost()  # 実際のコスト
@@ -82,9 +82,9 @@ class TestIntersectionToMiddle(unittest.TestCase):
         i2m.current_edge = "none"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5480 + \
+        motion_time = 0.553 + \
             GameMotion.ROTATION_BLOCK_TABLE[45]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.94
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2m.get_cost()  # 実際のコスト
@@ -112,9 +112,9 @@ class TestIntersectionToMiddle(unittest.TestCase):
         i2m.current_edge = "none"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5480 + \
+        motion_time = 0.553 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[45]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.94
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2m.get_cost()  # 実際のコスト
@@ -142,9 +142,9 @@ class TestIntersectionToMiddle(unittest.TestCase):
         i2m.current_edge = "none"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5480 + \
+        motion_time = 0.553 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[180]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.94
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = i2m.get_cost()  # 実際のコスト

--- a/tests/test_middle_to_block.py
+++ b/tests/test_middle_to_block.py
@@ -21,9 +21,9 @@ class TestMiddleToBlock(unittest.TestCase):
         m2b.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.6970 + GameMotion.ROTATION_BLOCK_TABLE[270]["time"] \
+        motion_time = 0.697 + GameMotion.ROTATION_BLOCK_TABLE[270]["time"] \
             + GameMotion.VERTICAL_TIME + GameMotion.SLEEP_TIME * 2
-        success_rate = 1.0
+        success_rate = 0.78
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2b.get_cost()  # 実際のコスト
@@ -56,9 +56,9 @@ class TestMiddleToBlock(unittest.TestCase):
         m2b.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.6970 + \
+        motion_time = 0.697 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[315]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 1.0
+        success_rate = 0.78
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2b.get_cost()  # 実際のコスト

--- a/tests/test_middle_to_intersection.py
+++ b/tests/test_middle_to_intersection.py
@@ -21,9 +21,9 @@ class TestMiddleToIntersection(unittest.TestCase):
         m2i.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5560 + \
+        motion_time = 0.645 + \
             GameMotion.ROTATION_BLOCK_TABLE[225]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.96
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2i.get_cost()  # 実際のコスト
@@ -51,9 +51,9 @@ class TestMiddleToIntersection(unittest.TestCase):
         m2i.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5560 + \
+        motion_time = 0.645 + \
             GameMotion.ROTATION_BLOCK_TABLE[270]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.96
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2i.get_cost()  # 実際のコスト
@@ -80,9 +80,9 @@ class TestMiddleToIntersection(unittest.TestCase):
         m2i.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5560 + \
+        motion_time = 0.645 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[90]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.96
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2i.get_cost()  # 実際のコスト
@@ -109,9 +109,9 @@ class TestMiddleToIntersection(unittest.TestCase):
         m2i.current_edge = "right"  # 初期エッジを右エッジにする
 
         # コストの期待値を求める
-        motion_time = 0.5560 + \
+        motion_time = 0.645 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[135]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.8
+        success_rate = 0.96
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2i.get_cost()  # 実際のコスト

--- a/tests/test_middle_to_middle.py
+++ b/tests/test_middle_to_middle.py
@@ -21,10 +21,10 @@ class TestMiddleToMiddle(unittest.TestCase):
         m2m.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 1.149 + \
+        motion_time = 1.3415 + \
             GameMotion.ROTATION_BLOCK_TABLE[45]["time"] + \
             GameMotion.DIAGONAL_TIME + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.5
+        success_rate = 0.6
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2m.get_cost()  # 実際のコスト
@@ -54,9 +54,9 @@ class TestMiddleToMiddle(unittest.TestCase):
         m2m.current_edge = "left"  # 初期エッジを左エッジにする
 
         # コストの期待値を求める
-        motion_time = 1.149 + \
+        motion_time = 1.3415 + \
             GameMotion.ROTATION_NO_BLOCK_TABLE[90]["time"] + GameMotion.SLEEP_TIME * 2
-        success_rate = 0.5
+        success_rate = 0.6
         expected_cost = motion_time*success_rate+GameMotion.MAX_TIME*(1-success_rate)
 
         actual_cost = m2m.get_cost()  # 実際のコスト


### PR DESCRIPTION
## チェックリスト

- [x] format(autopep8) している
- [x] コーディング規約(pep8)に準じている
- [x] チケットの完了条件を満たしている

## 変更点
- ゲームエリア動作の時間と成功率を計測した値に変更

### 実験データ
https://docs.google.com/spreadsheets/d/1oWvTgxDAb215ZaO_zJrXGAhXXGuTYOjqzEFAh92o0Ec/edit#gid=0
「#70 コスト算出」と「#70 動作時間」のシートを参照