### PR TITLE
close #69 datafiles/のすべてのファイルに権限与える

### DIFF
--- a/submit.sh
+++ b/submit.sh
@@ -15,8 +15,9 @@ SSH_TARGET="katlab@"$1
 DATA_DIRECTORY="datafiles"
 
 if [ -d ${DATA_DIRECTORY} ]; then
-    # 送信データディレクトリを機体に送信
+    # 送信データディレクトリを機体に送信後，機体のデータディレクトリに権限を付与する
     scp -r ${DATA_DIRECTORY} ${SSH_TARGET}:~/work/RasPike/sdk/workspace/etrobocon2022/
+    ssh ${SSH_TARGET} "chmod 777 ~/work/RasPike/sdk/workspace/etrobocon2022/${DATA_DIRECTORY}/*"
     echo "Completed ${DATA_DIRECTORY} submission."
 else
     echo "\"${DATA_DIRECTORY}\" does not exist."


### PR DESCRIPTION
## チェックリスト

- [x] format(autopep8) している
- [x] コーディング規約(pep8)に準じている
- [x] チケットの完了条件を満たしている

## 変更点

- scpコマンドで送信した走行体の`datafiles/`に対して，sshでchmodを実行して権限を付与する処理を追加

## 動作テスト

`datafiles/`送信後に，走行体側の`datafiles/`に権限(777)が付与されていることを確認